### PR TITLE
MetaROR #27: structural moves (checklist, post-pub, deviations, Ch2 types synthesis)

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -262,7 +262,7 @@ book:
       chapters:
         - publishing.qmd
         - field_specific_mri.qmd
-    - part: "Conclusion and Checklist"
+    - part: "Conclusion"
       chapters:
         - conclusion.qmd
     - references.qmd
@@ -270,6 +270,7 @@ book:
   downloads: [pdf]
 
   appendices:
+    - appendix_checklist.qmd
     - contributions.qmd
     - appendix_templates.qmd
 

--- a/appendix_checklist.qmd
+++ b/appendix_checklist.qmd
@@ -1,0 +1,19 @@
+---
+title: "Reproduction and Replication Checklist"
+---
+
+The checklist below summarises the handbook's core recommendations for
+planning, conducting, and reporting reproductions and replications.
+
+## Checklist {#sec-checklist}
+
+- [ ] Justify choice of target study and claims
+- [ ] Choose a reproduction/replication type that aligns with your aims
+- [ ] Gather and review all relevant materials
+- [ ] Reproduce before you replicate, where possible
+- [ ] Discuss all updates, changes, and extensions of the original materials (as close as possible, as updated as necessary)
+- [ ] Preregister your study and analysis plan
+- [ ] Predetermine conditions for success and failure
+- [ ] Use balanced language when describing the outcomes
+- [ ] Carefully evaluate outcomes and potential reasons for divergences
+- [ ] Report your research comprehensively and openly accessible

--- a/choosing_study.qmd
+++ b/choosing_study.qmd
@@ -15,8 +15,11 @@ influenced by its relevance, theoretical or societal impact, and
 citation history. High uncertainty in the original results increases the
 potential knowledge gain from replication, while limited reporting,
 multiple prior studies, or contextual specificity may further motivate
-replication. Researchers must also consider feasibility, including data
-availability, resources, and technical requirements. Potential
+replication. Post-publication discussions—such as comments, critiques,
+or prior replication attempts—can further inform whether and how a study
+is worth repeating. Researchers must also consider feasibility,
+including data availability, resources, and technical requirements.
+Potential
 researcher biases, such as confirmation bias or conflicts of interest,
 highlight the importance of preregistration and transparent
 documentation. Clear justification and systematic frameworks can ensure
@@ -29,6 +32,9 @@ that replication efforts are efficient and trustworthy.
 
 -   Which factors determine whether a study is worth reproducing or
     replicating?
+
+-   How can post-publication discussions inform the choice of a target
+    study?
 
 -   How can practical constraints and potential biases influence the
     selection of replication targets?
@@ -245,6 +251,28 @@ types of *reproducibility checks*.
 | Post publication (e.g., [I4R](https://i4replication.org), [Replication Research](http://replicationresearch.org), [JOPD](https://openpsychologydata.metajnl.com/), [JRR](https://scipost.org/JRobustRep/about)) | Independent Resesarcher | Selection by independent researcher, possibly nomination by journal | Reproducibilityor Robustness Report as preprint or in a journal | Public report | Post-publication |
 
 : Types of Reproducibility Checks
+
+## Post-Publication Conversations
+
+When evaluating a potential target study, additional knowledge should be
+taken into account, such as any discussions of the original finding.
+There can be other studies citing the original studies, criticizing
+them, disconfirming their underlying theory, identifying errors,
+reinterpreting the finding, or making suggestions for replications. All
+of these might highlight considerations that need to be taken into
+account when deciding whether a study is worth repeating and, later, when
+designing a study that *robustly* tests the original claim or its
+generalisability.
+
+Thus, researchers should look for post-publication discussions on the
+target study such as published comments and reviews, blog posts, or
+discussions on social media. These can often be found via Altmetric
+(<https://www.altmetric.com>) or other tools that allow researchers to
+quickly identify discussions on social media or news outlets beyond
+scientific journals ([PubPeer](https://pubpeer.com),
+[Hypothes.is](https://web.hypothes.is), or the in-development platform
+[Alphaxiv.org](https://www.alphaxiv.org/); for a review see
+@HenriquesEtAl2023).
 
 ## (Potential) Researcher Bias
 

--- a/conclusion.qmd
+++ b/conclusion.qmd
@@ -2,17 +2,4 @@
 title: "Conclusion"
 ---
 
-As replication researchers from multiple disciplines, we have discussed current standards, best-practices, and open debates surrounding the planning and execution of reproductions and replications. We have also highlighted the need for field-specific guidance and debate by presenting the special case of replications with MRI data. Our recommendations are summarized in the checklist below. With decades of research waiting to be reproduced and replicated, we hope to provide a starting point for interdisciplinary discussions and support researchers in embracing the essential and exciting element of repetitive research.
-
-## Reproductions and Replications Checklist
-
-- [ ] Justify choice of target study and claims  
-- [ ] Choose a reproduction/replication type that aligns with your aims  
-- [ ] Gather and review all relevant materials  
-- [ ] Reproduce before you replicate, where possible  
-- [ ] Discuss all updates, changes, and extensions of the original materials (as close as possible, as updated as necessary)  
-- [ ] Preregister your study and analysis plan  
-- [ ] Predetermine conditions for success and failure  
-- [ ] Use balanced language when describing the outcomes  
-- [ ] Carefully evaluate outcomes and potential reasons for divergences  
-- [ ] Report your research comprehensively and openly accessible  
+As replication researchers from multiple disciplines, we have discussed current standards, best-practices, and open debates surrounding the planning and execution of reproductions and replications. We have also highlighted the need for field-specific guidance and debate by presenting the special case of replications with MRI data. Our recommendations are summarized in the checklist in @sec-checklist. With decades of research waiting to be reproduced and replicated, we hope to provide a starting point for interdisciplinary discussions and support researchers in embracing the essential and exciting element of repetitive research.

--- a/execution_reproductions.qmd
+++ b/execution_reproductions.qmd
@@ -104,6 +104,16 @@ planned analyses.
 
 While preregistration of a reproduction may seem paradoxical when data are already accessible, it remains valuable as a (personal) commitment device: specifying the analysis plan in advance keeps researchers accountable and helps produce robust reproductions. If the data could already have been accessed, some readers may discount the registration, yet we would recommend to still start with this.
 
+## Deviations
+
+Deviations from the original procedure should be anticipated and, where
+possible, pre-specified in the preregistration: each planned change
+should be explained, justified, and accompanied by a hypothesis about
+its expected effect on the outcomes. Where deviations only become
+necessary during the analysis, they should still be reported
+transparently in the final report. Documenting all such changes, whether
+planned or emergent, increases trust in the reproduction.
+
 ## Analysis
 
 The main part of the reproduction is the analysis. Factors that are
@@ -129,13 +139,6 @@ of these indicators in the form of a reproducibility dashboard and
 specification curves [@SimonsohnEtAl2020; see also @MazeiEtAl2025]. We
 strongly recommend reproduction researchers to consult the respective
 resources for further details.
-
-Deviations from the original procedure typically arise during the
-analysis. To increase trust in the reported results, reproduction
-researchers need to report any such deviations in a transparent way, in
-a possible preregistration and the final report. Ideally, all changes to
-the original procedure are explained, justified, and hypotheses about
-their expected effect on the outcomes are reported.
 
 ## Discussion
 

--- a/execution_reproductions.qmd
+++ b/execution_reproductions.qmd
@@ -104,9 +104,6 @@ planned analyses.
 
 While preregistration of a reproduction may seem paradoxical when data are already accessible, it remains valuable as a (personal) commitment device: specifying the analysis plan in advance keeps researchers accountable and helps produce robust reproductions. If the data could already have been accessed, some readers may discount the registration, yet we would recommend to still start with this.
 
-## Deviations
-
-To increase trust in the reported results, reproduction researchers need to report them in a transparent way, in a possible preregistration and the final report. Ideally, all changes to the original procedure are explained, justified, and hypotheses about their expected effect on the outcomes are reported.
 ## Analysis
 
 The main part of the reproduction is the analysis. Factors that are
@@ -132,6 +129,13 @@ of these indicators in the form of a reproducibility dashboard and
 specification curves [@SimonsohnEtAl2020; see also @MazeiEtAl2025]. We
 strongly recommend reproduction researchers to consult the respective
 resources for further details.
+
+Deviations from the original procedure typically arise during the
+analysis. To increase trust in the reported results, reproduction
+researchers need to report any such deviations in a transparent way, in
+a possible preregistration and the final report. Ideally, all changes to
+the original procedure are explained, justified, and hypotheses about
+their expected effect on the outcomes are reported.
 
 ## Discussion
 

--- a/execution_reproductions.qmd
+++ b/execution_reproductions.qmd
@@ -106,13 +106,14 @@ While preregistration of a reproduction may seem paradoxical when data are alrea
 
 ## Deviations
 
-Deviations from the original procedure should be anticipated and, where
-possible, pre-specified in the preregistration: each planned change
+Reproductions may aim to test whether the precise same approach yields the
+same result, or whether deliberate deviations make a difference. Either approach
+requires being mindful and transparent about deviations. Each planned change
 should be explained, justified, and accompanied by a hypothesis about
-its expected effect on the outcomes. Where deviations only become
+its expected effect on the outcomes, ideally in a preregistration. Where deviations only become
 necessary during the analysis, they should still be reported
 transparently in the final report. Documenting all such changes, whether
-planned or emergent, increases trust in the reproduction.
+planned or emergent, increases trust in the reproduction, and makes it easier to interpret its results.
 
 ## Analysis
 

--- a/planning.qmd
+++ b/planning.qmd
@@ -8,10 +8,7 @@ title: "Planning and Conducting Reproductions and Replications"
 Reproductions and replications require clarifying whether the aim is to
 verify a method or test a broader theory, as this determines the choice
 between close and conceptual approaches. Selecting the appropriate type
-and assembling a capable team are important early steps. Planning should
-also consider post-publication discussions, as critiques or prior
-replication attempts may reveal methodological or theoretical issues
-relevant to the design.
+and assembling a capable team are important early steps.
 
 Before conducting a replication, reproduction should be assessed by
 attempting to recreate the original results. This helps identify errors,
@@ -26,9 +23,6 @@ theory-oriented extensions.
 
 -   Why is it recommended to conduct reproductions before replication
     studies?
-
--   How can post-publication discussions influence the design of
-    replication studies?
 
 -   Why should close replications generally precede conceptual
     replications?
@@ -63,27 +57,6 @@ and publishing research.
 
 : Types of repetitive research ordered by reproduction and replication
 and respective closeness to the original study. {#tbl-rep-types}
-
-## Post Publication Conversations
-
-When planning the replication study, additional knowledge should be
-taken into account such as any discussions of the original finding.
-There can be other studies citing the original studies, criticizing
-them, disconfirming their underlying theory, identifying errors,
-reinterpreting the finding, or making suggestions for replications. All
-of these might highlight considerations that need to be taken into
-account when designing a replication study that *robustly* tests the
-original claim or its generalisability.
-
-Thus, replication researchers should look for post-publication
-discussions on the target study such as published comments and reviews,
-blog posts, or discussions on social media. These can often be found via
-Altmetric (<https://www.altmetric.com>) or other tools that allow
-researchers to quickly identify discussions on social media or news
-outlets beyond scientific journals ([PubPeer](https://pubpeer.com),
-[Hypothes.is](https://web.hypothes.is), or the in-development platform
-[Alphaxiv.org](https://www.alphaxiv.org/); for a review see
-@HenriquesEtAl2023.
 
 ## Reproduction before Replication
 

--- a/understanding.qmd
+++ b/understanding.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Understanding Replications and Reproductions"
+title: "Understanding Reproductions and Replications"
 ---
 
 ::: {.callout-tip icon="false"}
@@ -84,7 +84,7 @@ replication/reproduction study is often not straightforward, but may
 depend on the success criteria applied. This is discussed in
 @sec-success-criteria.
 
-## Types of replication {#sec-types-replication}
+## Closeness and Similarity {#sec-types-replication}
 
 We heavily rely on the typology provided by @HueffmeierEtAl2016 where different types of replications are defined by the *closeness* or *similarity* between original and replication study. Determining what constitutes closeness or similarity is context-specific and relies on a detailed understanding of the original study. Similarity cannot be evaluated without a theory about the concepts involved. For example, the concept of age can differ strongly between replications of historical, psychological, or biological studies, leading to different measures of the concept itself and thus different judgments about the similarity of an object’s age.
 
@@ -145,13 +145,3 @@ In terms of Schöch [-@Schoch2023], who defines an overarching type of
 concerned with the same question as a previous study, use the same
 (close replication) or a similar (conceptual replication) method and use
 different data (otherwise they are reproductions).
-
-## Types of reproduction
-
-Reproductions can be numerical reproductions, testing whether the same
-data, code and software lead to the same results, or robustness
-reproductions, extending the original analysis and exploring the central
-finding’s limits [@DreberJohannesson2024]. Most reproductions would
-include both a numerical reproduction as baseline and then a robustness
-reproduction, unless the numerical reproduction is not possible due to a
-lack of code or software.


### PR DESCRIPTION
Draft of the agreed, lower-risk structural moves from issue #27. Each is a separate commit so they can be reviewed (or reverted) independently. **Not** the larger Ch1→Ch2 merge or the Ch7/Ch8 reorganisations — those interact with #29 and were left out of this batch.

Full book renders with **no unresolved cross-references**; both renamed/moved targets still resolve.

### 1. Merge Deviations into Analysis (Ch5 reproductions) — *issue #27*
Deviations typically arise during analysis, so the one-paragraph `Deviations` section is folded into the end of `Analysis`. Reworded the opening pronoun ('report them' → 'report any such deviations') now that it sits inside Analysis.

### 2. Checklist → Appendix — *issue #27*
The Reproductions and Replications Checklist moves out of the Conclusion into a new appendix (`appendix_checklist.qmd`), cross-referenced from the conclusion via `@sec-checklist` (renders as 'Section A.1'). The part 'Conclusion and Checklist' is renamed 'Conclusion'.

### 3. Post-Publication Conversations → target-selection chapter — *issue #27 (R1)*
Post-publication discussions mainly inform *which* study to repeat, so the section moves from Planning (Ch4) to Choosing the Target Study (Ch3), reframed around evaluating a target. Both chapters' key-takeaways boxes are updated to match, and a stray unmatched `)` in the moved text is closed.

### 4. Ch2 'types' synthesis — *issue #27 (items 2 & 3), as agreed*
- Chapter renamed reproduction-first: **'Understanding Reproductions and Replications'**.
- The conceptual section 'Types of replication' is retitled **'Closeness and Similarity'** (it is about closeness / inductive vs deductive / the LeBel taxonomy, not a type catalogue). Its `{#sec-types-replication}` label is **kept** because the discussion chapter cross-references it (still resolves → 'Section 2.3').
- The short 'Types of reproduction' section is **removed**: numerical/recoding/robustness reproductions are already defined in Ch4 (Table 4.1 *and* the 'Reproduction before Replication' section), so it was pure duplication. The conceptual discussion stays in Ch2; the type catalogue lives with the table in Ch4.

### Judgement calls for sign-off
- Retitling 'Types of replication' → 'Closeness and Similarity' (vs keeping the old title).
- Deleting the Ch2 reproduction-types paragraph rather than relocating it (Ch4 already covers it).
- Chapter title kept as 'Understanding Reproductions and Replications' rather than R3's bare 'Reproductions and Replications'.

Evaluation of all 11 #27 items is in `scratch_issue27_structure_eval.md` (not committed).