### PR TITLE
Separate publishing from other communication (Ch8, #21)

### DIFF
--- a/publishing.qmd
+++ b/publishing.qmd
@@ -22,18 +22,19 @@ authors should keep in mind the historical context of the original
 publication. For example, sharing data was much more difficult in the
 1990s and not required in many areas until recently.
 
-The journals that published the original studies are often also chosen
-by authors for publication in accordance with the *pottery-barn-rule*
-[@Srivastava2012]. However, in our experience, many journals reject
-replications due to their lack of novelty. We list several options for
-writing and publishing the report in @tbl-reporting-options. These are
-non-exclusive, that is, researchers can choose multiple of them. An
-overview of active journals that exclusively publish replications is in
-@tbl-rep-journals. Note that the Journal of Reproducibility in
-Neuroscience (<https://jrn.trialanderror.org>) has been discontinued and
-AIS Transactions on Replication Research
-(<https://aisel.aisnet.org/trr/>) has been moved into a journal that is
-not specialized on repetitions.
+Communicating a replication and formally publishing it in a
+peer-reviewed journal are distinct, complementary activities, and they
+are not mutually exclusive. Researchers can make their findings visible
+and citable without a traditional journal, they can pursue journal
+publication, or they can do both. @tbl-reporting-options lists the main
+options, and researchers can choose one, several, or all of them. The
+first two options, the FORRT Replication Database and PubPeer, make a
+replication findable without writing a full manuscript. A manuscript,
+the traditional form of a research article, can in turn be released as a
+preprint, which makes it openly available and citable before peer
+review, and the same manuscript can also be submitted to a journal.
+Posting a preprint and submitting to a journal are therefore
+complementary rather than competing choices.
 
 | Type | Description |
 |----|----|
@@ -45,6 +46,23 @@ not specialized on repetitions.
 
 : Reporting and communicating reproductions and replications.
 {#tbl-reporting-options}
+
+For researchers who pursue traditional journal publication, the journals
+that published the original studies are a natural target, in accordance
+with the *pottery-barn rule* [@Srivastava2012], under which a journal
+that published an original finding should also publish replications of
+it. In our experience, however, many journals reject replications due to
+their lack of novelty, and many are not yet interested in replications
+at all. Partly in response, journals dedicated to replications have
+emerged, and @tbl-rep-journals lists active examples. Note that the
+Journal of Reproducibility in Neuroscience
+(<https://jrn.trialanderror.org>) has been discontinued and AIS
+Transactions on Replication Research (<https://aisel.aisnet.org/trr/>)
+has been moved into a journal that is not specialized on repetitions.
+Researchers can also submit a preprint to a PCI community (see
+<https://peercommunityin.org/current-pcis>), a preprint peer-review
+service, and several journals are PCI-friendly, meaning that they
+publish articles recommended by the respective PCI.
 
 Many institutions and libraries recommend adding a CC-BY disclaimer on
 journal submissions that give the researchers the right to use the

--- a/publishing.qmd
+++ b/publishing.qmd
@@ -24,8 +24,8 @@ publication. For example, sharing data was much more difficult in the
 
 Communicating a replication and formally publishing it in a
 peer-reviewed journal are distinct, complementary activities, and they
-are not mutually exclusive. Researchers can make their findings visible
-and citable without a traditional journal, they can pursue journal
+are not mutually exclusive. Researchers can make their findings visible,
+linkable, and in some cases citable without a traditional journal, they can pursue journal
 publication, or they can do both. @tbl-reporting-options lists the main
 options, and researchers can choose one, several, or all of them. The
 first two options, the FORRT Replication Database and PubPeer, make a
@@ -50,10 +50,11 @@ complementary rather than competing choices.
 For researchers who pursue traditional journal publication, the journals
 that published the original studies are a natural target, in accordance
 with the *pottery-barn rule* [@Srivastava2012], under which a journal
-that published an original finding should also publish replications of
-it. In our experience, however, many journals reject replications due to
-their lack of novelty, and many are not yet interested in replications
-at all. Partly in response, journals dedicated to replications have
+that published an original finding should consider publishing
+methodologically sound replications of findings it originally published.
+In our experience, however, many journals reject replications due to
+their lack of novelty, and some remain reluctant to consider
+replications. Partly in response, journals dedicated to replications have
 emerged, and @tbl-rep-journals lists active examples. Note that the
 Journal of Reproducibility in Neuroscience
 (<https://jrn.trialanderror.org>) has been discontinued and AIS
@@ -61,8 +62,8 @@ Transactions on Replication Research (<https://aisel.aisnet.org/trr/>)
 has been moved into a journal that is not specialized on repetitions.
 Researchers can also submit a preprint to a PCI community (see
 <https://peercommunityin.org/current-pcis>), a preprint peer-review
-service, and several journals are PCI-friendly, meaning that they
-publish articles recommended by the respective PCI.
+service, and several journals are PCI-friendly, meaning they may
+consider or publish articles recommended by the respective PCI.
 
 Many institutions and libraries recommend adding a CC-BY disclaimer on
 journal submissions that give the researchers the right to use the


### PR DESCRIPTION
Addresses the two R1 points in #21.

## What changed (only `publishing.qmd`)

1. **Separated traditional journal publishing from other communication channels.** Added a framing paragraph after the intro that distinguishes (a) making a replication visible and citable through channels that require no journal (FORRT Replication Database, PubPeer, preprints) from (b) formally publishing in a peer-reviewed journal. The journal-specific material (pottery-barn rule, journals rejecting replications for lack of novelty, dedicated replication journals, discontinued journals, PCI peer review) is now collected into its own paragraph after the reporting-options table, leading into the dedicated-journals table.

2. **Made explicit that the two are not mutually exclusive.** The framing paragraph states that researchers can make findings public without a traditional journal, pursue journal publication, or do both, and that posting a preprint and submitting to a journal are complementary rather than competing choices.

Both existing tables (reporting options and dedicated replication journals) are kept intact; no new citations, journals, or facts were introduced. Renders cleanly with no broken citations.

## Out of scope
The Ch8 -> Ch5/6 structural move (relocating/splitting this chapter) is **not** done here; that is deferred to #27.