### PR TITLE
Add many-analyst findings alongside Landy et al. (Ch2, #15)

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -198,7 +198,8 @@
   volume = {582},
   number = {7810},
   pages = {84-88},
-  year = {2020}
+  year = {2020},
+  doi = {10.1038/s41586-020-2314-9}
 }
 
 @article{BoyceEtAl2024,
@@ -217,6 +218,17 @@
   pages = {217-224},
   year = {2014},
   doi = {10.1016/j.jesp.2013.10.005}
+}
+
+@article{BreznauEtAl2022,
+  author = {Breznau, N. and Rinke, E. M. and Wuttke, A. and Nguyen, H. H. V. and Adem, M. and Adriaans, J. and Alvarez-Benjumea, A.},
+  title = {Observing many researchers using the same data and hypothesis reveals a hidden universe of uncertainty},
+  journal = {Proceedings of the National Academy of Sciences},
+  volume = {119},
+  number = {44},
+  pages = {e2203150119},
+  year = {2022},
+  doi = {10.1073/pnas.2203150119}
 }
 
 @article{BrodeurEtAl2024a,
@@ -1407,6 +1419,17 @@
   pages = {430-445},
   year = {2018},
   doi = {10.1002/bdm.2065}
+}
+
+@article{SilberzahnEtAl2018,
+  author = {Silberzahn, R. and Uhlmann, E. L. and Martin, D. P. and Anselmi, P. and Aust, F. and Awtrey, E. and Bahník, Š.},
+  title = {Many analysts, one data set: Making transparent how variations in analytic choices affect results},
+  journal = {Advances in Methods and Practices in Psychological Science},
+  volume = {1},
+  number = {3},
+  pages = {337-356},
+  year = {2018},
+  doi = {10.1177/2515245917747646}
 }
 
 @article{SimmonsEtAl2011,

--- a/references.bib
+++ b/references.bib
@@ -192,7 +192,7 @@
 }
 
 @article{BotvinikNezerEtAl2020,
-  author = {Botvinik-Nezer, R. and Holzmeister, F. and Camerer, C. F. and Dreber, A. and Huber, J. and Johannesson, M. and Rieck, J. R.},
+  author = {Botvinik-Nezer, R. and Holzmeister, F. and Camerer, C. F. and Dreber, A. and Huber, J. and Johannesson, M. and Rieck, J. R. and others},
   title = {Variability in the analysis of a single neuroimaging dataset by many teams},
   journal = {Nature},
   volume = {582},
@@ -221,7 +221,7 @@
 }
 
 @article{BreznauEtAl2022,
-  author = {Breznau, N. and Rinke, E. M. and Wuttke, A. and Nguyen, H. H. V. and Adem, M. and Adriaans, J. and Alvarez-Benjumea, A.},
+  author = {Breznau, N. and Rinke, E. M. and Wuttke, A. and Nguyen, H. H. V. and Adem, M. and Adriaans, J. and Alvarez-Benjumea, A. and others},
   title = {Observing many researchers using the same data and hypothesis reveals a hidden universe of uncertainty},
   journal = {Proceedings of the National Academy of Sciences},
   volume = {119},
@@ -1422,7 +1422,7 @@
 }
 
 @article{SilberzahnEtAl2018,
-  author = {Silberzahn, R. and Uhlmann, E. L. and Martin, D. P. and Anselmi, P. and Aust, F. and Awtrey, E. and Bahník, Š.},
+  author = {Silberzahn, R. and Uhlmann, E. L. and Martin, D. P. and Anselmi, P. and Aust, F. and Awtrey, E. and Bahník, Š. and others},
   title = {Many analysts, one data set: Making transparent how variations in analytic choices affect results},
   journal = {Advances in Methods and Practices in Psychological Science},
   volume = {1},

--- a/understanding.qmd
+++ b/understanding.qmd
@@ -125,6 +125,22 @@ close replications more directly test the credibility of original
 results, while conceptual replications that vary features of the design
 are concerned with generalizability.
 
+A related line of work isolates the analysis stage by holding the data
+fixed. In so-called many-analyst studies, multiple independent teams
+analyse the same dataset to test the same hypothesis, yet reach divergent
+conclusions. @SilberzahnEtAl2018 had numerous teams estimate whether
+football referees are more likely to give red cards to dark-skinned
+players, and the teams reported a wide spread of effect estimates despite
+working from identical data. @BotvinikNezerEtAl2020 observed comparable
+variability when many teams tested hypotheses on a single neuroimaging
+dataset, and @BreznauEtAl2022 described a “hidden universe of
+uncertainty” across the many teams that analysed the same survey data.
+Because the data are held constant, this variability stems from analytic
+flexibility alone, which matters for interpreting reproductions and
+replications: even when the same data are reanalysed, defensible
+differences in modelling decisions can move a result from supporting to
+contradicting the original claim.
+
 Note that @NosekErrington2020 define replication as a study “for which
 any outcome would be considered diagnostic evidence about a claim from
 prior research”. This can lead to issues when the original claim is not

--- a/understanding.qmd
+++ b/understanding.qmd
@@ -131,15 +131,17 @@ analyse the same dataset to test the same hypothesis, yet reach divergent
 conclusions. @SilberzahnEtAl2018 had numerous teams estimate whether
 football referees are more likely to give red cards to dark-skinned
 players, and the teams reported a wide spread of effect estimates despite
-working from identical data. @BotvinikNezerEtAl2020 observed comparable
+working from identical data. @BotvinikNezerEtAl2020 observed substantial
 variability when many teams tested hypotheses on a single neuroimaging
 dataset, and @BreznauEtAl2022 described a “hidden universe of
 uncertainty” across the many teams that analysed the same survey data.
-Because the data are held constant, this variability stems from analytic
-flexibility alone, which matters for interpreting reproductions and
+Because the data are held constant, this variability cannot be attributed
+to differences in data collection and instead reflects choices made in the
+analysis pipeline, which matters for interpreting reproductions and
 replications: even when the same data are reanalysed, defensible
-differences in modelling decisions can move a result from supporting to
-contradicting the original claim.
+differences in modelling decisions can change effect estimates, their
+uncertainty, statistical significance, and sometimes the direction of the
+substantive conclusion.
 
 Note that @NosekErrington2020 define replication as a study “for which
 any outcome would be considered diagnostic evidence about a claim from

--- a/understanding.qmd
+++ b/understanding.qmd
@@ -125,23 +125,26 @@ close replications more directly test the credibility of original
 results, while conceptual replications that vary features of the design
 are concerned with generalizability.
 
-A related line of work isolates the analysis stage by holding the data
-fixed. In so-called many-analyst studies, multiple independent teams
-analyse the same dataset to test the same hypothesis, yet reach divergent
-conclusions. @SilberzahnEtAl2018 had numerous teams estimate whether
-football referees are more likely to give red cards to dark-skinned
-players, and the teams reported a wide spread of effect estimates despite
-working from identical data. @BotvinikNezerEtAl2020 observed substantial
-variability when many teams tested hypotheses on a single neuroimaging
-dataset, and @BreznauEtAl2022 described a “hidden universe of
-uncertainty” across the many teams that analysed the same survey data.
-Because the data are held constant, this variability cannot be attributed
-to differences in data collection and instead reflects choices made in the
-analysis pipeline, which matters for interpreting reproductions and
-replications: even when the same data are reanalysed, defensible
-differences in modelling decisions can change effect estimates, their
-uncertainty, statistical significance, and sometimes the direction of the
-substantive conclusion.
+Analytic choices form a further dimension of similarity, which the
+taxonomy in @fig-taxonomy-similarity does not cover. Many-analyst studies
+isolate it by giving independent teams the same data and the same
+hypothesis, so that any variation in the results has to come from the
+analysis. @SilberzahnEtAl2018 asked 29 teams whether football referees
+are more likely to give red cards to dark-skin-toned players; the
+estimated effects ranged from 0.89 to 2.93 in odds-ratio units, and 20
+teams reported a significant positive effect while 9 did not. Among 70
+teams analysing a single neuroimaging dataset, no two chose the same
+workflow, and the results of the hypothesis tests varied accordingly
+[@BotvinikNezerEtAl2020]. @BreznauEtAl2022 gave 73 teams the same survey
+data to test whether higher immigration reduces support for social
+policies; the teams reached widely diverging numerical estimates and
+substantive conclusions, and researchers’ expertise and prior beliefs
+barely predicted where a team landed. Working from the same data
+therefore does not guarantee the same result. Only a numerical
+reproduction, which reuses the original code, holds the analysis fixed as
+well; every other repetition varies along this dimension, whether or not
+that is intended. Robustness reproductions, discussed in later chapters,
+turn this variation into a deliberate test.
 
 Note that @NosekErrington2020 define replication as a study “for which
 any outcome would be considered diagnostic evidence about a claim from


### PR DESCRIPTION
Addresses #15 (R1). Adds a focused paragraph after the existing Landy et al. discussion in `understanding.qmd` covering many-analyst studies, where multiple independent teams analyse the same data and reach divergent conclusions. This makes explicit that analytic flexibility alone (holding the data fixed) produces substantial outcome variability, which matters for interpreting reproductions and replications.

Studies cited: Silberzahn et al. (2018), Botvinik-Nezer et al. (2020), Breznau et al. (2022).

References:
- `BotvinikNezerEtAl2020` reused (already in bib); added its verified DOI 10.1038/s41586-020-2314-9.
- `SilberzahnEtAl2018` new, DOI 10.1177/2515245917747646.
- `BreznauEtAl2022` new, DOI 10.1073/pnas.2203150119.

All DOIs verified via Crossref. Render had no broken citations.

Note: references.bib is also touched by open PR #35 (different region; alphabetical inserts, should auto-merge).