### PR TITLE
Ch4/5: own paragraph for robustness reproductions; shuffled-data protocol suggestion (#18)

### DIFF
--- a/execution_reproductions.qmd
+++ b/execution_reproductions.qmd
@@ -104,6 +104,18 @@ planned analyses.
 
 While preregistration of a reproduction may seem paradoxical when data are already accessible, it remains valuable as a (personal) commitment device: specifying the analysis plan in advance keeps researchers accountable and helps produce robust reproductions. If the data could already have been accessed, some readers may discount the registration, yet we would recommend to still start with this.
 
+To develop and register the analysis protocol without being steered by the
+results, researchers can work on a masked version of the data in which the
+outcome (or condition) is randomly shuffled across cases, breaking the
+pairing between each record and its result. Such a masked dataset preserves
+the marginal distribution of each variable and the structural information
+needed to build and debug the analysis pipeline, for example variable types,
+value ranges, missing-data patterns, and the code paths that each step
+exercises, while withholding the directional relationships between predictors
+and outcomes. Finalising the protocol on this masked version, and only then
+applying it to the intact data, reduces the risk that analytic choices are
+consciously or unconsciously adjusted to produce a particular result.
+
 ## Deviations
 
 Reproductions may aim to test whether the precise same approach yields the

--- a/execution_reproductions.qmd
+++ b/execution_reproductions.qmd
@@ -106,15 +106,19 @@ While preregistration of a reproduction may seem paradoxical when data are alrea
 
 To develop and register the analysis protocol without being steered by the
 results, researchers can work on a masked version of the data in which the
-outcome (or condition) is randomly shuffled across cases, breaking the
-pairing between each record and its result. Such a masked dataset preserves
-the marginal distribution of each variable and the structural information
-needed to build and debug the analysis pipeline, for example variable types,
-value ranges, missing-data patterns, and the code paths that each step
-exercises, while withholding the directional relationships between predictors
-and outcomes. Finalising the protocol on this masked version, and only then
-applying it to the intact data, reduces the risk that analytic choices are
-consciously or unconsciously adjusted to produce a particular result.
+outcome column is randomly shuffled across cases, breaking the link between
+each record and its result. Shuffling an experimental condition or treatment
+label is only appropriate with design-aware masking. Such a masked dataset
+preserves the marginal distributions of the shuffled and unchanged variables,
+while often retaining enough structural information to build and debug much of
+the analysis pipeline, for example variable types, value ranges, missing-data
+patterns, and the code paths that each step exercises, while withholding the
+directional relationships between predictors and outcomes. For clustered,
+paired, longitudinal, blocked, or stratified designs, any shuffling should
+respect the relevant design structure. Finalising the protocol on this masked
+version, and only then applying it to the intact data, can reduce the risk
+that analytic choices are consciously or unconsciously adjusted to produce a
+particular result.
 
 ## Deviations
 

--- a/execution_reproductions.qmd
+++ b/execution_reproductions.qmd
@@ -106,14 +106,14 @@ While preregistration of a reproduction may seem paradoxical when data are alrea
 
 To develop and register the analysis protocol without being steered by the
 results, researchers can work on a masked version of the data, for instance
-one in which the outcome is randomly shuffled across cases. Simple shuffling
-may not be enough, particularly if the protocol needs to test distributional
-assumptions, and in such cases the masked data should be generated in a way
-that takes the design and structure of the data into account, for which
-@Quintana2020 offers a helpful tutorial. Finalising the protocol on this
-masked version, and only then applying it to the intact data, can reduce the
-risk that analytic choices are consciously or unconsciously adjusted to
-produce a particular result.
+one in which the outcome is randomly shuffled across cases. This preserves
+the distribution of each variable, so most of the analysis pipeline can be
+written and debugged, but it breaks the relationships between variables, so
+checks that depend on them, such as residual diagnostics, can only be run on
+the intact data and should be specified as decision rules in the protocol.
+Finalising the protocol on this masked version, and only then applying it to
+the intact data, can reduce the risk that analytic choices are consciously or
+unconsciously adjusted to produce a particular result.
 
 ## Deviations
 

--- a/execution_reproductions.qmd
+++ b/execution_reproductions.qmd
@@ -105,15 +105,18 @@ planned analyses.
 While preregistration of a reproduction may seem paradoxical when data are already accessible, it remains valuable as a (personal) commitment device: specifying the analysis plan in advance keeps researchers accountable and helps produce robust reproductions. If the data could already have been accessed, some readers may discount the registration, yet we would recommend to still start with this.
 
 To develop and register the analysis protocol without being steered by the
-results, researchers can work on a masked version of the data, for instance
-one in which the outcome is randomly shuffled across cases. This preserves
-the distribution of each variable, so most of the analysis pipeline can be
-written and debugged, but it breaks the relationships between variables, so
-checks that depend on them, such as residual diagnostics, can only be run on
-the intact data and should be specified as decision rules in the protocol.
-Finalising the protocol on this masked version, and only then applying it to
-the intact data, can reduce the risk that analytic choices are consciously or
-unconsciously adjusted to produce a particular result.
+results, researchers can work on a blinded version of the data, for instance
+one in which the outcome is randomly shuffled across cases while the
+predictors are left intact [@DutilhEtAl2021; @MacCounPerlmutter2015]. The
+distribution of each variable stays intact, as does any collinearity among
+the predictors, so the analysis pipeline can be written, debugged, and
+adapted to peculiarities of the data, while any association with the outcome
+is due to chance alone. Shuffling the condition labels instead is less
+suitable for factorial designs, since mixing groups with different
+distributions can disguise the skew within each of them and prompt the wrong
+transformation. Finalising the protocol on the blinded data, and only then
+applying it unchanged to the intact data, reduces the risk that analytic
+choices are adjusted, consciously or not, to produce a particular result.
 
 ## Deviations
 

--- a/execution_reproductions.qmd
+++ b/execution_reproductions.qmd
@@ -105,20 +105,15 @@ planned analyses.
 While preregistration of a reproduction may seem paradoxical when data are already accessible, it remains valuable as a (personal) commitment device: specifying the analysis plan in advance keeps researchers accountable and helps produce robust reproductions. If the data could already have been accessed, some readers may discount the registration, yet we would recommend to still start with this.
 
 To develop and register the analysis protocol without being steered by the
-results, researchers can work on a masked version of the data in which the
-outcome column is randomly shuffled across cases, breaking the link between
-each record and its result. Shuffling an experimental condition or treatment
-label is only appropriate with design-aware masking. Such a masked dataset
-preserves the marginal distributions of the shuffled and unchanged variables,
-while often retaining enough structural information to build and debug much of
-the analysis pipeline, for example variable types, value ranges, missing-data
-patterns, and the code paths that each step exercises, while withholding the
-directional relationships between predictors and outcomes. For clustered,
-paired, longitudinal, blocked, or stratified designs, any shuffling should
-respect the relevant design structure. Finalising the protocol on this masked
-version, and only then applying it to the intact data, can reduce the risk
-that analytic choices are consciously or unconsciously adjusted to produce a
-particular result.
+results, researchers can work on a masked version of the data, for instance
+one in which the outcome is randomly shuffled across cases. Simple shuffling
+may not be enough, particularly if the protocol needs to test distributional
+assumptions, and in such cases the masked data should be generated in a way
+that takes the design and structure of the data into account, for which
+@Quintana2020 offers a helpful tutorial. Finalising the protocol on this
+masked version, and only then applying it to the intact data, can reduce the
+risk that analytic choices are consciously or unconsciously adjusted to
+produce a particular result.
 
 ## Deviations
 

--- a/planning.qmd
+++ b/planning.qmd
@@ -83,19 +83,21 @@ special attention should be paid to processing steps such as exclusion
 of outliers, transformation of variables, and handling of missing data.
 However, in many research areas information on these steps is often
 incomplete [@FieldEtAl2019]; older research tends to be especially
-limited in terms of the methodological details they provide. In
-addition, we recommend testing the robustness of the original finding by
-making small alterations to the data processing and analyses procedure
-(*robustness reproductions*). For example, if the analyses were run for
-a subset of the data (e.g., participants aged 21 to 30 or without
-outliers ± 3 standard deviations), this subset can be changed (e.g.,
-participants aged 18 to 30 or without outliers ± 2 standard deviations).
-Here, the initial focus should be on choices that are not determined by
-the *theory* that is presented, though this can also be used to explore
-the generalisability of some aspects of theory. Finally, if the original
+limited in terms of the methodological details they provide. If the original
 study was preregistered and the original code is available, reproduction
-researchers can check whether the original analyses adhere to the
+researchers can also check whether the original analyses adhere to the
 preregistered analysis plan.
+
+Beyond reproducing the original analyses as reported, we recommend testing
+the robustness of the original finding by making small alterations to the
+data processing and analyses procedure (*robustness reproductions*). For
+example, if the analyses were run for a subset of the data (e.g.,
+participants aged 21 to 30 or without outliers ± 3 standard deviations),
+this subset can be changed (e.g., participants aged 18 to 30 or without
+outliers ± 2 standard deviations). Here, the initial focus should be on
+choices that are not determined by the *theory* that is presented, though
+this can also be used to explore the generalisability of some aspects of
+theory.
 
 If neither code nor data are available (or shared by the authors), no
 reproduction is possible. Researchers can still use automated tools to

--- a/planning.qmd
+++ b/planning.qmd
@@ -85,7 +85,7 @@ However, in many research areas information on these steps is often
 incomplete [@FieldEtAl2019]; older research tends to be especially
 limited in terms of the methodological details they provide. If the original
 study was preregistered and the original code is available, reproduction
-researchers can also check whether the original analyses adhere to the
+researchers can check whether the original analyses adhere to the
 preregistered analysis plan.
 
 Beyond reproducing the original analyses as reported, we recommend testing

--- a/references.bib
+++ b/references.bib
@@ -1297,16 +1297,6 @@
   doi = {10.31219/osf.io/rju75_v1}
 }
 
-@article{Quintana2020,
-  author = {Quintana, D. S.},
-  title = {A synthetic dataset primer for the biobehavioural sciences to promote reproducibility and hypothesis generation},
-  journal = {eLife},
-  volume = {9},
-  pages = {e53275},
-  year = {2020},
-  doi = {10.7554/eLife.53275}
-}
-
 @article{RentonEtAl2024,
   author = {Renton, A. I. and Dao, T. T. and Johnstone, T. and Civier, O. and Sullivan, R. P. and White, D. J. and Lyons, P. and Slade, B. M. and Abbott, D. F. and Amos, T. J. and Bollmann, S. and Botting, A. and Campbell, M. E. J. and Chang, J. and Close, T. G. and Dörig, M. and Eckstein, K. and Egan, G. F. and Evas, S. and Bollmann, S.},
   title = {Neurodesk: an accessible, flexible and portable data analysis environment for reproducible neuroimaging},

--- a/references.bib
+++ b/references.bib
@@ -415,6 +415,17 @@
   doi = {10.1037/11020-022}
 }
 
+@article{DutilhEtAl2021,
+  author = {Dutilh, G. and Sarafoglou, A. and Wagenmakers, E.-J.},
+  title = {Flexible yet fair: Blinding analyses in experimental psychology},
+  journal = {Synthese},
+  volume = {198},
+  number = {S23},
+  pages = {5745-5772},
+  year = {2021},
+  doi = {10.1007/s11229-019-02456-7}
+}
+
 @article{EbersoleEtAl2020,
   author = {Ebersole, C. R. and Mathur, M. B. and Baranski, E. and Bart-Plange, D. J. and Buttrick, N. R. and Chartier, C. R. and Szecsi, P.},
   title = {Many Labs 5: Testing pre-data-collection peer review as an intervention to increase replicability},
@@ -999,6 +1010,17 @@
   pages = {624–633},
   year = {2024},
   doi = {10.1038/s41586-024-07805-2}
+}
+
+@article{MacCounPerlmutter2015,
+  author = {MacCoun, R. and Perlmutter, S.},
+  title = {Blind analysis: Hide results to seek the truth},
+  journal = {Nature},
+  volume = {526},
+  number = {7572},
+  pages = {187-189},
+  year = {2015},
+  doi = {10.1038/526187a}
 }
 
 @article{Mahoney1977,

--- a/references.bib
+++ b/references.bib
@@ -1297,6 +1297,16 @@
   doi = {10.31219/osf.io/rju75_v1}
 }
 
+@article{Quintana2020,
+  author = {Quintana, D. S.},
+  title = {A synthetic dataset primer for the biobehavioural sciences to promote reproducibility and hypothesis generation},
+  journal = {eLife},
+  volume = {9},
+  pages = {e53275},
+  year = {2020},
+  doi = {10.7554/eLife.53275}
+}
+
 @article{RentonEtAl2024,
   author = {Renton, A. I. and Dao, T. T. and Johnstone, T. and Civier, O. and Sullivan, R. P. and White, D. J. and Lyons, P. and Slade, B. M. and Abbott, D. F. and Amos, T. J. and Bollmann, S. and Botting, A. and Campbell, M. E. J. and Chang, J. and Close, T. G. and Dörig, M. and Eckstein, K. and Egan, G. F. and Evas, S. and Bollmann, S.},
   title = {Neurodesk: an accessible, flexible and portable data analysis environment for reproducible neuroimaging},


### PR DESCRIPTION
Addresses #18 (R1). Touches planning.qmd (§4.2 split) and execution_reproductions.qmd (Preregistration). Note: 'Reproduction before Replication' is now §4.2 in planning.qmd after the recent restructure, hence the file.

- planning.qmd: robustness reproductions now get their own clearly-delineated paragraph; the numerical/recoding reproduction and preregistration-adherence sentences are regrouped into the preceding paragraph. All content and citations preserved.
- execution_reproductions.qmd: added a recommendation in the Preregistration section to develop and register the analysis protocol on a masked dataset (outcome/condition shuffled across cases), which preserves marginal distributions and pipeline structure while withholding directional results. No citation added (no clearly-matching Crossref-verified source found).