### PR TITLE
Match the blinding scheme to the design (Ch5, #18)

### DIFF
--- a/execution_reproductions.qmd
+++ b/execution_reproductions.qmd
@@ -105,18 +105,21 @@ planned analyses.
 While preregistration of a reproduction may seem paradoxical when data are already accessible, it remains valuable as a (personal) commitment device: specifying the analysis plan in advance keeps researchers accountable and helps produce robust reproductions. If the data could already have been accessed, some readers may discount the registration, yet we would recommend to still start with this.
 
 To develop and register the analysis protocol without being steered by the
-results, researchers can work on a blinded version of the data, for instance
-one in which the outcome is randomly shuffled across cases while the
-predictors are left intact [@DutilhEtAl2021; @MacCounPerlmutter2015]. The
-distribution of each variable stays intact, as does any collinearity among
-the predictors, so the analysis pipeline can be written, debugged, and
-adapted to peculiarities of the data, while any association with the outcome
-is due to chance alone. Shuffling the condition labels instead is less
-suitable for factorial designs, since mixing groups with different
-distributions can disguise the skew within each of them and prompt the wrong
-transformation. Finalising the protocol on the blinded data, and only then
-applying it unchanged to the intact data, reduces the risk that analytic
-choices are adjusted, consciously or not, to produce a particular result.
+results, researchers can work on a blinded version of the data
+[@DutilhEtAl2021; @MacCounPerlmutter2015]. For regression designs,
+@DutilhEtAl2021 recommend shuffling the outcome across cases and leaving the
+predictors intact, so that the distribution of each variable, and any
+collinearity among the predictors, stays available to model, while any
+association with the outcome is due to chance alone. For designs that compare
+group means they recommend a different scheme: subtracting the cell mean from
+each observation and masking the labels of the factor levels, which hides the
+effect while leaving the shape of the distribution within each cell intact.
+Shuffling cannot do that, since it breaks the association under test, so any
+check that depends on that association has to be fixed as a decision rule in
+the protocol rather than inspected on the blinded data. Finalising the
+protocol on the blinded data, and only then applying it unchanged to the
+intact data, reduces the risk that analytic choices are adjusted, consciously
+or not, to produce a particular result.
 
 ## Deviations
 


### PR DESCRIPTION
Follow-up to #41. That PR cited Dutilh et al. (2021) for the shuffled-data protocol, but drew only on their methods section, where "shuffle the criterion Y" appears. Their recommendations section splits by design:

- **Regression designs (§5.1)**: shuffle the criterion Y, leave the predictors intact, so predictor collinearity stays available to model.
- **ANOVA designs (§5.3)**: do not shuffle. Subtract the cell mean from each observation and mask the labels of the factor levels, "because this shuffling of condition indicators will also distort the form of the within-cell distributions of the dependent variable… This way, the effects of interest are masked while the distribution of the data is left intact."

The merged wording named only the shuffling scheme and said label shuffling is "less suitable for factorial designs", which implies outcome shuffling is the answer there. It is not. Checked against the published Synthese version; it matches the preprint on both passages.

Also restores the caveat dropped in #41: checks that depend on the association under test cannot be validated on blinded data and need to be fixed as decision rules. It was right, just over-scoped to relationships in general rather than the association being tested.

No reference changes. Renders cleanly, no broken citations.