### PR TITLE
Show the How to Cite section only in the PDF (#45)

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -15,13 +15,15 @@ scholarship
 cat(paste("Last update:", Sys.Date()))
 ```
 
+::: {.content-visible when-format="pdf"}
 ## How to Cite
 
 Please cite this handbook as:
 
-Röseler, L.\**,* Wallrich, L.\*, Hartmann, H., Hüffmeier, J.,
-Goltermann, J., Pennington, C. R., Boyce, V., Field, S. M., Pittelkow,
-M.-M., Silverstein, P., van Ravenzwaaij, D., Azevedo, F. (2025).
-*Handbook for Reproduction and Replication Studies.* Retrieved from
-<https://forrt.org/replication-handbook/>,
+Röseler, L.\*, Wallrich, L.\*, Hartmann, H., Altegoer, L., Boyce, V.,
+Field, S., Goltermann, J., Hüffmeier, J., Moser, V., Pennington, C. R.,
+Pittelkow, M.-M., Silverstein, P., van Ravenzwaaij, D., Azevedo, F.
+(2026). *Handbook for Reproduction and Replication Studies.* Retrieved
+from <https://forrt.org/replication-handbook/>.
 <https://doi.org/10.5281/zenodo.16990114> \*shared first authorship
+:::


### PR DESCRIPTION
The HTML site already shows the full citation in the page footer, defined in `_quarto.yml`, so the "How to Cite" section on the landing page repeated it.

The section is now wrapped in `::: {.content-visible when-format="pdf"}`, so it appears only in the PDF, which has no footer. Its citation text was updated to match the footer exactly: 2026 author list including Altegoer and Moser, same URL, DOI and shared-first-authorship note.

Closes #45
