### PR TITLE
Note that deviations from a preregistration can affect robustness (#63)

### DIFF
--- a/planning.qmd
+++ b/planning.qmd
@@ -86,7 +86,7 @@ incomplete [@FieldEtAl2019]; older research tends to be especially
 limited in terms of the methodological details they provide. If the original
 study was preregistered and the original code is available, reproduction
 researchers can check whether the original analyses adhere to the
-preregistered analysis plan.
+preregistered analysis plan, and whether deviations affected robustness.
 
 Beyond reproducing the original analyses as reported, we recommend testing
 the robustness of the original finding by making small alterations to the


### PR DESCRIPTION
Extends the "Reproduction before Replication" section in `planning.qmd` to note that reproduction researchers should also check whether deviations from a preregistered analysis plan affected robustness.

Closes #63
