### PR TITLE
Enable lightbox for figures in the HTML book (#53)

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -290,6 +290,7 @@ format:
       light: [cosmo, theme.scss]
     fig-cap-location: top
     link-external-newwindow: true
+    lightbox: true
 
   pdf:
     documentclass: scrbook


### PR DESCRIPTION
Turns on Quarto's built-in lightbox for the HTML book, by adding `lightbox: true` to the `format: html` block in `_quarto.yml`. Readers can now click any figure to open it enlarged in an overlay, with the figure caption shown underneath and arrows to step through the other figures on the same page. This helps most for the dense flowcharts and screenshots, which are otherwise limited to the width of the text column. The PDF format is unchanged, and no chapter sources were edited. The two logo images on the landing page also become clickable, which leaves the page layout as it was.

Closes #53
