### PR TITLE
Move multiverse analysis into the reproduction analysis section (#56)

### DIFF
--- a/execution_reproductions.qmd
+++ b/execution_reproductions.qmd
@@ -158,6 +158,19 @@ specification curves [@SimonsohnEtAl2020; see also @MazeiEtAl2025]. We
 strongly recommend reproduction researchers to consult the respective
 resources for further details.
 
+Where several processing and analysis choices are defensible, a robustness
+reproduction can be extended into a multiverse analysis, which systematically
+evaluates reasonable combinations of those choices and reports the estimates
+obtained across all of them, rather than selecting a single analysis
+[@SteegenEtAl2016]. The specification curve mentioned above is the common way
+to display such a set of estimates, ordered by size and shown alongside the
+analytical choices that produced them, and it can be accompanied by a test of
+whether the observed curve is more extreme than would be expected under a null
+effect [@SimonsohnEtAl2020]. Both approaches make sensitivity to analytical
+choices visible, yet they are resource-intensive and only as informative as
+the specifications they cover, so that set should be justified and, ideally,
+preregistered.
+
 ## Discussion
 
 The discussion section should include a clear evaluation of the

--- a/planning.qmd
+++ b/planning.qmd
@@ -49,7 +49,6 @@ and publishing research.
 | Computational Reproduction | Reanalysis of the same data with the same code | Correctness of original report |
 | Recoding reproduction | Reanalysis of the same data, with new (equivalent) code | Correctness of original report |
 | Robustness Reproduction | Reanalysis of the same data with new coding choices; can vary in closeness | Robustness of original finding and sensitivity to different analytical decisions or software |
-| Multiverse analysis | Analyze data in all sensible ways (i.e., a large number of different robustness reproductions) | Robustness and generalizability of original finding, identification of potential moderators or sources for effect variability |
 | Internal replication | Replicate one of your own studies as closely as possible | Demonstrate generalizability across studies; rule out false-positives (e.g., for new discoveries) |
 | Close / direct / exact replication | Conduct a new study (based on work by other researchers) that is as close as possible to the original study | Rule out a false-positive original finding, validate original materials or design, check generalizability/external validity for theoretically irrelevant variables (e.g., population, year of data collection) |
 | Close replication with extension | Add a variable or procedure to a close replication | Rule out a false-positive original finding, test generalizability of original finding |

--- a/references.bib
+++ b/references.bib
@@ -1528,6 +1528,17 @@
   doi = {10.1038/s41586-023-05745-x}
 }
 
+@article{SteegenEtAl2016,
+  author = {Steegen, S. and Tuerlinckx, F. and Gelman, A. and Vanpaemel, W.},
+  title = {Increasing transparency through a multiverse analysis},
+  journal = {Perspectives on Psychological Science},
+  volume = {11},
+  number = {5},
+  pages = {702-712},
+  year = {2016},
+  doi = {10.1177/1745691616658637}
+}
+
 @article{SteinerEtAl2023,
   author = {Steiner, P. M. and Sheehan, P. and Wong, V. C.},
   title = {Correspondence measures for assessing replication success},


### PR DESCRIPTION
Multiverse analysis is a way of running many robustness reproductions, not a separate type of repetitive research, so it sat awkwardly alongside the other rows of the study-type table.

- `planning.qmd`: removed the "Multiverse analysis" row from @tbl-rep-types. The remaining "Robustness Reproduction" row covers sensitivity to analytical decisions, and no other text in the chapter referred to the removed row.
- `execution_reproductions.qmd`: added a short paragraph at the end of the *Analysis* section. It describes extending a robustness reproduction into a multiverse analysis, links it to the specification curve already mentioned in the preceding paragraph, and notes that such analyses are resource-intensive and that the set of specifications should be justified and ideally preregistered.
- `references.bib`: added `SteegenEtAl2016` (Crossref-verified DOI 10.1177/1745691616658637). `SimonsohnEtAl2020` already existed.

The chapter renders without citation or cross-reference warnings.

Closes #56
