### PR TITLE
Add mini meta-analysis guidance for mixed original results (#64)

### DIFF
--- a/choosing_study.qmd
+++ b/choosing_study.qmd
@@ -183,18 +183,15 @@ power should be taken with caution [see also @Francis2012;
 @Schimmack2012; @LakensEtz2017].
 
 When the original studies show mixed results, with some significant and
-some not, or with effects of clearly different size, an internal or
-‘mini’ meta-analysis can pool their effect estimates into a single
-estimate with a confidence interval, which is generally more informative
-than a count of significant findings, provided the studies are
-comparable enough and the analysis accounts for their precision and
-heterogeneity [@GohEtAl2016]. Differences between the studies, for
-instance in samples, operationalizations or settings, can generate
-hypotheses about boundary conditions that a replication could
-deliberately test, although such differences are post hoc and often
-confounded, so they do not establish boundary conditions on their own. A
-pooled estimate from a single lab’s own studies can itself be distorted
-by selective reporting, so the caution above still applies
+some not, or effects of clearly different size, an internal or “mini”
+meta-analysis pools their estimates into a single effect size with a
+confidence interval, which conveys the uncertainty better than a count of
+significant findings [@GohEtAl2016]. Differences between the studies, for
+instance in samples, operationalizations or settings, can suggest boundary
+conditions that a replication could test deliberately, though such post
+hoc comparisons generate hypotheses rather than establishing them. A
+pooled estimate from a single lab’s studies can still be distorted by
+selective reporting, so the caution above continues to apply
 [@VosgerauEtAl2019].
 
 For large parts of the literature and given the overall low replicability rate in many fields, the mere lack of a reproduction or close replication by independent researchers can be used as an argument for uncertainty [e.g., @PittelkowEtAl2023], though it *might* also indicate that nobody beyond the original orders is interested in the phenomenon. However, it is also possible that replications have been attempted but not published, for instance when reviewers show an aversion to null findings, replications, or findings criticizing their own work.

--- a/choosing_study.qmd
+++ b/choosing_study.qmd
@@ -182,6 +182,21 @@ significant findings when each of the studies does not have very high
 power should be taken with caution [see also @Francis2012;
 @Schimmack2012; @LakensEtz2017].
 
+When the original studies show mixed results, with some significant and
+some not, or with effects of clearly different size, an internal or
+‘mini’ meta-analysis can pool their effect estimates into a single
+estimate with a confidence interval, which is generally more informative
+than a count of significant findings, provided the studies are
+comparable enough and the analysis accounts for their precision and
+heterogeneity [@GohEtAl2016]. Differences between the studies, for
+instance in samples, operationalizations or settings, can generate
+hypotheses about boundary conditions that a replication could
+deliberately test, although such differences are post hoc and often
+confounded, so they do not establish boundary conditions on their own. A
+pooled estimate from a single lab’s own studies can itself be distorted
+by selective reporting, so the caution above still applies
+[@VosgerauEtAl2019].
+
 For large parts of the literature and given the overall low replicability rate in many fields, the mere lack of a reproduction or close replication by independent researchers can be used as an argument for uncertainty [e.g., @PittelkowEtAl2023], though it *might* also indicate that nobody beyond the original orders is interested in the phenomenon. However, it is also possible that replications have been attempted but not published, for instance when reviewers show an aversion to null findings, replications, or findings criticizing their own work.
 
 Finally, uncertainty can be the result of a lack of specificity in the

--- a/references.bib
+++ b/references.bib
@@ -1640,6 +1640,17 @@
   doi = {10.1177/0956797621989733}
 }
 
+@article{VosgerauEtAl2019,
+  author = {Vosgerau, J. and Simonsohn, U. and Nelson, L. D. and Simmons, J. P.},
+  title = {99\% impossible: A valid, or falsifiable, internal meta-analysis},
+  journal = {Journal of Experimental Psychology: General},
+  volume = {148},
+  number = {9},
+  pages = {1628-1639},
+  year = {2019},
+  doi = {10.1037/xge0000663}
+}
+
 @article{WagenmakersEtAl2016,
   author = {Wagenmakers, E.-J. and Beek, T. and Dijkhoff, L. and Gronau, Q. F. and Acosta, A. and Adams, R. B. and Albohn, D. N. and Allard, E. S. and Benning, S. D. and Blouin-Hudon, E.-M. and Bulnes, L. C. and Caldwell, T. L. and Calin-Jageman, R. J. and Capaldi, C. A. and Carfagno, N. S. and Chasten, K. T. and Cleeremans, A. and Connell, L. and DeCicco, J. M. and Zwaan, R. A.},
   title = {Registered Replication Report: Strack, Martin, & Stepper (1988)},


### PR DESCRIPTION
Adds one short paragraph to the "Uncertainty" section of `choosing_study.qmd`, directly after the power-deflation paragraph, covering the case where the original paper reports a mix of significant and non-significant results.

The paragraph makes three points:

- An internal or "mini" meta-analysis of the original studies can pool their effect estimates into one estimate with a confidence interval, which is generally more informative than counting significant studies, provided the studies are comparable enough and the analysis accounts for precision and heterogeneity (Goh, Hall & Rosenthal, 2016).
- Differences between the studies (samples, operationalizations, settings) can generate hypotheses about boundary conditions for a replication to test, while noting that such differences are post hoc and often confounded.
- A pooled estimate from a single lab's own studies can itself be distorted by selective reporting, so the caution in the preceding paragraph still applies (Vosgerau, Simonsohn, Nelson & Simmons, 2019).

`GohEtAl2016` already existed in `references.bib`. `VosgerauEtAl2019` is new, with Crossref-verified metadata (doi 10.1037/xge0000663); the `%` in the title is escaped for BibTeX.

Chapter renders without citation or cross-reference warnings.

Closes #64
